### PR TITLE
Add React Native support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@badcafe/jsonizer",
   "version": "9.0.3",
   "description": "Structural reviving for JSON",
+  "main": "dist/index.cjs",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
React Native was failing to work for me with this package because it could not find the index file. It expects to look in the 'main' property of package.json. We need to specify a file within dist/ to make this work.